### PR TITLE
Adding Must convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ default: help
 vet:
 	@go vet -v .\...
 
+## tidy: cleans up mod dependencies
+.PHONY: tidy 
+tidy:
+	@go mod tidy
+
 ## test: runs all tests
 .PHONY: test
 test: 

--- a/amqp/bus.go
+++ b/amqp/bus.go
@@ -1,8 +1,9 @@
 package amqp
 
 import (
-	base "github.com/movidesk/go-bus"
 	"sync"
+
+	base "github.com/movidesk/go-bus"
 )
 
 type BusOptionsFn func(*BusOptions)
@@ -23,6 +24,7 @@ type Bus interface {
 	NewPublisher(fns ...PublisherOptionsFn) (base.Publisher, error)
 	NewSubscriber(fns ...SubscriberOptionsFn) (base.Subscriber, error)
 }
+
 type bus struct {
 	_ struct{}
 	*BusOptions

--- a/amqp/bus.go
+++ b/amqp/bus.go
@@ -36,6 +36,14 @@ type bus struct {
 	wg    *sync.WaitGroup
 }
 
+func MustBus(fns ...BusOptionsFn) Bus {
+	bus, err := NewBus(fns...)
+	if err != nil {
+		panic(err)
+	}
+	return bus
+}
+
 func NewBus(fns ...BusOptionsFn) (Bus, error) {
 	o := &BusOptions{}
 	SetBusDSN("amqp://guest:guest@localhost:5672")(o)

--- a/amqp/bus_test.go
+++ b/amqp/bus_test.go
@@ -20,6 +20,10 @@ func (s *BusIntegrationSuite) SetupTest() {
 	declareTopic("amqp://guest:guest@localhost:5672", s.exchange, s.queue)
 }
 
+func (s *BusIntegrationSuite) TearDownTest() {
+	deleteTopic("amqp://guest:guest@localhost:5672", s.exchange, s.queue)
+}
+
 func (s *BusIntegrationSuite) TestNewBus() {
 	assert := s.Assert()
 

--- a/amqp/bus_test.go
+++ b/amqp/bus_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	uuid "github.com/satori/go.uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -22,7 +21,7 @@ func (s *BusIntegrationSuite) SetupTest() {
 }
 
 func (s *BusIntegrationSuite) TestNewBus() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	bus, err := NewBus()
 	assert.NoError(err)
@@ -30,7 +29,7 @@ func (s *BusIntegrationSuite) TestNewBus() {
 }
 
 func (s *BusIntegrationSuite) TestNewPublisher() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	bus, err := NewBus()
 	assert.NoError(err)
@@ -42,7 +41,7 @@ func (s *BusIntegrationSuite) TestNewPublisher() {
 }
 
 func (s *BusIntegrationSuite) TestNewSubscriber() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	bus, err := NewBus()
 	assert.NoError(err)
@@ -54,7 +53,7 @@ func (s *BusIntegrationSuite) TestNewSubscriber() {
 }
 
 func (s *BusIntegrationSuite) TestSubscribeWithAck() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	bus, err := NewBus()
 	assert.NoError(err)
@@ -93,7 +92,7 @@ out:
 }
 
 func (s *BusIntegrationSuite) TestSubscribeWithNack() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	bus, err := NewBus()
 	assert.NoError(err)

--- a/amqp/bus_test.go
+++ b/amqp/bus_test.go
@@ -49,6 +49,19 @@ func (s *BusIntegrationSuite) TestNewPublisher() {
 	assert.NotNil(pub)
 }
 
+func (s *BusIntegrationSuite) TestMustPublisher() {
+	assert := s.Assert()
+
+	assert.NotPanics(func() {
+		bus, err := NewBus()
+		assert.NoError(err)
+		assert.NotNil(bus)
+
+		pub := bus.MustPublisher()
+		assert.NotNil(pub)
+	})
+}
+
 func (s *BusIntegrationSuite) TestNewSubscriber() {
 	assert := s.Assert()
 
@@ -59,6 +72,19 @@ func (s *BusIntegrationSuite) TestNewSubscriber() {
 	sub, err := bus.NewSubscriber()
 	assert.NoError(err)
 	assert.NotNil(sub)
+}
+
+func (s *BusIntegrationSuite) TestMustSubscriber() {
+	assert := s.Assert()
+
+	assert.NotPanics(func() {
+		bus, err := NewBus()
+		assert.NoError(err)
+		assert.NotNil(bus)
+
+		sub := bus.MustSubscriber()
+		assert.NotNil(sub)
+	})
 }
 
 func (s *BusIntegrationSuite) TestSubscribeWithAck() {

--- a/amqp/bus_test.go
+++ b/amqp/bus_test.go
@@ -28,6 +28,15 @@ func (s *BusIntegrationSuite) TestNewBus() {
 	assert.NotNil(bus)
 }
 
+func (s *BusIntegrationSuite) TestMustBus() {
+	assert := s.Assert()
+
+	assert.NotPanics(func() {
+		bus := MustBus()
+		assert.NotNil(bus)
+	})
+}
+
 func (s *BusIntegrationSuite) TestNewPublisher() {
 	assert := s.Assert()
 

--- a/amqp/channel.go
+++ b/amqp/channel.go
@@ -62,6 +62,14 @@ type Channel struct {
 	closed int32
 }
 
+func MustChannel(conn *Connection, fns ...ChannelOptionsFn) *Channel {
+	chnn, err := NewChannel(conn, fns...)
+	if err != nil {
+		panic(err)
+	}
+	return chnn
+}
+
 func NewChannel(conn *Connection, fns ...ChannelOptionsFn) (*Channel, error) {
 	o := &ChannelOptions{
 		wg:    &sync.WaitGroup{},

--- a/amqp/channel_test.go
+++ b/amqp/channel_test.go
@@ -179,6 +179,7 @@ func (s *ChannelIntegrationSuite) TestChannelConsume() {
 	assert.NotNil(chnn)
 
 	declareTopic("amqp://guest:guest@localhost:5672", "exchange-a", "queue-a")
+	defer deleteTopic("amqp://guest:guest@localhost:5672", "exchange-a", "queue-a")
 
 	err = chnn.Publish("exchange-a", "", false, false, amqp.Publishing{Body: []byte("body")})
 	assert.NoError(err)
@@ -214,6 +215,7 @@ func (s *ChannelIntegrationSuite) TestChannelConsumeOnNetworkFailure() {
 	assert.NotNil(chnn)
 
 	declareTopic("amqp://guest:guest@localhost:5672", "exchange-b", "queue-b")
+	defer deleteTopic("amqp://guest:guest@localhost:5672", "exchange-b", "queue-b")
 
 	err = chnn.Publish("exchange-b", "", false, false, amqp.Publishing{
 		DeliveryMode: amqp.Persistent,

--- a/amqp/channel_test.go
+++ b/amqp/channel_test.go
@@ -38,6 +38,21 @@ func (s *ChannelIntegrationSuite) TestNewChannel() {
 	assert.NotNil(chnn)
 }
 
+func (s *ChannelIntegrationSuite) TestMustChannel() {
+	assert := s.Assert()
+
+	assert.NotPanics(func() {
+		conn, err := NewConnection(
+			SetConnectionDSN("amqp://guest:guest@localhost:5672"),
+		)
+		assert.NoError(err)
+		assert.NotNil(conn)
+
+		chnn := MustChannel(conn)
+		assert.NotNil(chnn)
+	})
+}
+
 func (s *ChannelIntegrationSuite) TestNewChannelWithoutConfiguration() {
 	assert := s.Assert()
 

--- a/amqp/channel_test.go
+++ b/amqp/channel_test.go
@@ -7,7 +7,6 @@ import (
 
 	toxi "github.com/shopify/toxiproxy/client"
 	"github.com/streadway/amqp"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -26,7 +25,7 @@ func (s *ChannelIntegrationSuite) SetupTest() {
 }
 
 func (s *ChannelIntegrationSuite) TestNewChannel() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, err := NewConnection(
 		SetConnectionDSN("amqp://guest:guest@localhost:5672"),
@@ -40,7 +39,7 @@ func (s *ChannelIntegrationSuite) TestNewChannel() {
 }
 
 func (s *ChannelIntegrationSuite) TestNewChannelWithoutConfiguration() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, err := NewConnection()
 	assert.NoError(err)
@@ -52,7 +51,7 @@ func (s *ChannelIntegrationSuite) TestNewChannelWithoutConfiguration() {
 }
 
 func (s *ChannelIntegrationSuite) TestNewChannelWithProxy() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 	s.rabbit.Enable()
 	defer s.rabbit.Disable()
 
@@ -81,7 +80,7 @@ func (s *ChannelIntegrationSuite) TestNewChannelWithProxy() {
 }
 
 func (s *ChannelIntegrationSuite) TestChannelOnNetworkFailure() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 	s.rabbit.Enable()
 	defer s.rabbit.Disable()
 
@@ -110,7 +109,7 @@ func (s *ChannelIntegrationSuite) TestChannelOnNetworkFailure() {
 }
 
 func (s *ChannelIntegrationSuite) TestChannelWaitGroupOnClose() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, err := NewConnection()
 	assert.NoError(err)
@@ -130,7 +129,7 @@ func (s *ChannelIntegrationSuite) TestChannelWaitGroupOnClose() {
 }
 
 func (s *ChannelIntegrationSuite) TestChannelWaitGroupOnDone() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, err := NewConnection()
 	assert.NoError(err)
@@ -154,7 +153,7 @@ func (s *ChannelIntegrationSuite) TestChannelWaitGroupOnDone() {
 }
 
 func (s *ChannelIntegrationSuite) TestChannelConsume() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, err := NewConnection()
 	assert.NoError(err)
@@ -181,7 +180,7 @@ func (s *ChannelIntegrationSuite) TestChannelConsume() {
 }
 
 func (s *ChannelIntegrationSuite) TestChannelConsumeOnNetworkFailure() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 	s.rabbit.Enable()
 	defer s.rabbit.Disable()
 

--- a/amqp/connection.go
+++ b/amqp/connection.go
@@ -48,6 +48,14 @@ type Connection struct {
 	*ConnectionOptions
 }
 
+func MustConnection(fns ...ConnectionOptionsFn) *Connection {
+	conn, err := NewConnection(fns...)
+	if err != nil {
+		panic(err)
+	}
+	return conn
+}
+
 func NewConnection(fns ...ConnectionOptionsFn) (*Connection, error) {
 	o := &ConnectionOptions{
 		wg:    &sync.WaitGroup{},

--- a/amqp/connection_test.go
+++ b/amqp/connection_test.go
@@ -34,6 +34,18 @@ func (s *ConnectionIntegrationSuite) TestNewConnection() {
 	assert.NotNil(conn)
 }
 
+func (s *ConnectionIntegrationSuite) TestMustConnection() {
+	assert := s.Assert()
+
+	assert.NotPanics(func() {
+		conn := MustConnection(
+			SetConnectionDSN("amqp://guest:guest@localhost:5672"),
+		)
+
+		assert.NotNil(conn)
+	})
+}
+
 func (s *ConnectionIntegrationSuite) TestNewConnectionWithoutConfiguration() {
 	assert := s.Assert()
 

--- a/amqp/connection_test.go
+++ b/amqp/connection_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	toxi "github.com/shopify/toxiproxy/client"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -25,7 +24,7 @@ func (s *ConnectionIntegrationSuite) SetupTest() {
 }
 
 func (s *ConnectionIntegrationSuite) TestNewConnection() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, err := NewConnection(
 		SetConnectionDSN("amqp://guest:guest@localhost:5672"),
@@ -36,7 +35,7 @@ func (s *ConnectionIntegrationSuite) TestNewConnection() {
 }
 
 func (s *ConnectionIntegrationSuite) TestNewConnectionWithoutConfiguration() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, err := NewConnection()
 
@@ -45,7 +44,7 @@ func (s *ConnectionIntegrationSuite) TestNewConnectionWithoutConfiguration() {
 }
 
 func (s *ConnectionIntegrationSuite) TestNewConnectionWithInvalidDSN() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, err := NewConnection(
 		SetConnectionDSN("amqp://guest:guest@invalid:5672"),
@@ -56,7 +55,7 @@ func (s *ConnectionIntegrationSuite) TestNewConnectionWithInvalidDSN() {
 }
 
 func (s *ConnectionIntegrationSuite) TestNewConnectionWithProxy() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 	s.rabbit.Enable()
 	defer s.rabbit.Disable()
 
@@ -74,7 +73,7 @@ func (s *ConnectionIntegrationSuite) TestNewConnectionWithProxy() {
 }
 
 func (s *ConnectionIntegrationSuite) TestConnectionOnNetworkFailure() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 	s.rabbit.Enable()
 	defer s.rabbit.Disable()
 
@@ -96,7 +95,7 @@ func (s *ConnectionIntegrationSuite) TestConnectionOnNetworkFailure() {
 }
 
 func (s *ConnectionIntegrationSuite) TestConnectionOnNetworkFailureWithDelay() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 	s.rabbit.Enable()
 	defer s.rabbit.Disable()
 
@@ -122,7 +121,7 @@ func (s *ConnectionIntegrationSuite) TestConnectionOnNetworkFailureWithDelay() {
 }
 
 func (s *ConnectionIntegrationSuite) TestConnectionWaitGroupOnClose() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	wg := &sync.WaitGroup{}
 	conn, err := NewConnection(
@@ -143,7 +142,7 @@ func (s *ConnectionIntegrationSuite) TestConnectionWaitGroupOnClose() {
 }
 
 func (s *ConnectionIntegrationSuite) TestConnectionWaitGroupOnDone() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	wg := &sync.WaitGroup{}
 	done := make(chan struct{})

--- a/amqp/publisher.go
+++ b/amqp/publisher.go
@@ -87,6 +87,14 @@ type pub struct {
 	reconnected chan bool
 }
 
+func MustPublisher(sess *Session, fns ...PublisherOptionsFn) Publisher {
+	pub, err := NewPublisher(sess, fns...)
+	if err != nil {
+		panic(err)
+	}
+	return pub
+}
+
 func NewPublisher(sess *Session, fns ...PublisherOptionsFn) (Publisher, error) {
 	o := &PublisherOptions{}
 	wg := &sync.WaitGroup{}
@@ -126,10 +134,10 @@ func (p *pub) Publish(msg base.Message) (error, bool) {
 		return errors.New("Could not Publish, session connection is closed"), false
 	}
 
-	err := p.Session.Channel.Publish(p.exchange, p.key, p.mandatory, p.immediate,  amqp.Publishing{
+	err := p.Session.Channel.Publish(p.exchange, p.key, p.mandatory, p.immediate, amqp.Publishing{
 		DeliveryMode: amqp.Persistent,
-		Headers: msg.GetHeaders(),
-		Body: msg.GetBody(),
+		Headers:      msg.GetHeaders(),
+		Body:         msg.GetBody(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "Could not Publish, channel.Publish() failed"), false
@@ -180,4 +188,3 @@ out:
 		}
 	}
 }
-

--- a/amqp/publisher_test.go
+++ b/amqp/publisher_test.go
@@ -12,7 +12,7 @@ type PublisherIntegrationSuite struct {
 }
 
 func (s *PublisherIntegrationSuite) TestNewPublisher() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, _ := NewConnection()
 	sess, _ := NewSession(conn)
@@ -72,7 +72,7 @@ func (s *PublisherIntegrationSuite) TestPublishWithoutConfirmOnUnexistentExchang
 }
 
 func (s *PublisherIntegrationSuite) TestPublishWithoutConfirmOnExistentExchange() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, _ := NewConnection()
 	sess, _ := NewSession(conn)
@@ -88,7 +88,7 @@ func (s *PublisherIntegrationSuite) TestPublishWithoutConfirmOnExistentExchange(
 }
 
 func (s *PublisherIntegrationSuite) TestPublishWithHeaderAndBody() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, _ := NewConnection()
 	sess, _ := NewSession(conn)

--- a/amqp/publisher_test.go
+++ b/amqp/publisher_test.go
@@ -22,6 +22,19 @@ func (s *PublisherIntegrationSuite) TestNewPublisher() {
 	assert.NotNil(pub)
 }
 
+func (s *PublisherIntegrationSuite) TestMustPublisher() {
+	assert := s.Assert()
+
+	assert.NotPanics(func() {
+		conn, _ := NewConnection()
+		sess, _ := NewSession(conn)
+
+		pub := MustPublisher(sess)
+
+		assert.NotNil(pub)
+	})
+}
+
 func (s *PublisherIntegrationSuite) TestPublishWithConfirmOnUnexistentExchange() {
 	assert := assert.New(s.T())
 

--- a/amqp/session.go
+++ b/amqp/session.go
@@ -7,6 +7,14 @@ type Session struct {
 	*Channel
 }
 
+func MustSession(conn *Connection, fns ...ChannelOptionsFn) *Session {
+	sess, err := NewSession(conn, fns...)
+	if err != nil {
+		panic(err)
+	}
+	return sess
+}
+
 func NewSession(conn *Connection, fns ...ChannelOptionsFn) (*Session, error) {
 	chnn, err := NewChannel(conn, fns...)
 	if err != nil {

--- a/amqp/session_test.go
+++ b/amqp/session_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	toxi "github.com/shopify/toxiproxy/client"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -25,7 +24,7 @@ func (s *SessionIntegrationSuite) SetupTest() {
 }
 
 func (s *SessionIntegrationSuite) TestNewSession() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, err := NewConnection(
 		SetConnectionDSN("amqp://guest:guest@localhost:5672"),
@@ -39,7 +38,7 @@ func (s *SessionIntegrationSuite) TestNewSession() {
 }
 
 func (s *SessionIntegrationSuite) TestSessionWaitGroupOnClose() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	wg := &sync.WaitGroup{}
 	conn, err := NewConnection(
@@ -63,7 +62,7 @@ func (s *SessionIntegrationSuite) TestSessionWaitGroupOnClose() {
 }
 
 func (s *SessionIntegrationSuite) TestSessionWaitGroupOnDone() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	wg := &sync.WaitGroup{}
 	done := make(chan struct{})

--- a/amqp/session_test.go
+++ b/amqp/session_test.go
@@ -37,6 +37,21 @@ func (s *SessionIntegrationSuite) TestNewSession() {
 	assert.NotNil(sess)
 }
 
+func (s *SessionIntegrationSuite) TestMustSession() {
+	assert := s.Assert()
+
+	assert.NotPanics(func() {
+		conn, err := NewConnection(
+			SetConnectionDSN("amqp://guest:guest@localhost:5672"),
+		)
+		assert.NoError(err)
+		assert.NotNil(conn)
+
+		sess := MustSession(conn)
+		assert.NotNil(sess)
+	})
+}
+
 func (s *SessionIntegrationSuite) TestSessionWaitGroupOnClose() {
 	assert := s.Assert()
 

--- a/amqp/subscriber.go
+++ b/amqp/subscriber.go
@@ -59,6 +59,14 @@ type sub struct {
 	*Session
 }
 
+func MustSubscriber(sess *Session, fns ...SubscriberOptionsFn) Subscriber {
+	sub, err := NewSubscriber(sess, fns...)
+	if err != nil {
+		panic(err)
+	}
+	return sub
+}
+
 func NewSubscriber(sess *Session, fns ...SubscriberOptionsFn) (Subscriber, error) {
 	o := &SubscriberOptions{}
 	SetSubscriberDeliveries(make(chan base.Message, 1))(o)

--- a/amqp/subscriber_test.go
+++ b/amqp/subscriber_test.go
@@ -6,7 +6,6 @@ import (
 
 	uuid "github.com/satori/go.uuid"
 	toxi "github.com/shopify/toxiproxy/client"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -37,7 +36,7 @@ func (s *SubscriberIntegrationSuite) SetupTest() {
 }
 
 func (s *SubscriberIntegrationSuite) TestNewSubscriber() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, _ := NewConnection()
 	sess, _ := NewSession(conn)
@@ -49,7 +48,7 @@ func (s *SubscriberIntegrationSuite) TestNewSubscriber() {
 }
 
 func (s *SubscriberIntegrationSuite) TestConsumeOnClose() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 
 	conn, _ := NewConnection()
 	sess, _ := NewSession(conn)
@@ -83,7 +82,7 @@ out:
 }
 
 func (s *SubscriberIntegrationSuite) TestConsumeOnNetworkFailure() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 	s.rabbit.Enable()
 	defer s.rabbit.Disable()
 
@@ -149,7 +148,7 @@ func (s *SubscriberIntegrationSuite) TestConsumeOnNetworkFailure() {
 }
 
 func (s *SubscriberIntegrationSuite) TestConsumeOnNetworkFailureWhileMessageIsInFlight() {
-	assert := assert.New(s.T())
+	assert := s.Assert()
 	s.rabbit.Enable()
 	defer s.rabbit.Disable()
 

--- a/amqp/subscriber_test.go
+++ b/amqp/subscriber_test.go
@@ -46,6 +46,19 @@ func (s *SubscriberIntegrationSuite) TestNewSubscriber() {
 	assert.NotNil(sub)
 }
 
+func (s *SubscriberIntegrationSuite) TestMustSubscriber() {
+	assert := s.Assert()
+
+	assert.NotPanics(func() {
+		conn, _ := NewConnection()
+		sess, _ := NewSession(conn)
+
+		sub := MustSubscriber(sess)
+
+		assert.NotNil(sub)
+	})
+}
+
 func (s *SubscriberIntegrationSuite) TestConsumeOnClose() {
 	assert := s.Assert()
 

--- a/amqp/subscriber_test.go
+++ b/amqp/subscriber_test.go
@@ -34,6 +34,10 @@ func (s *SubscriberIntegrationSuite) SetupTest() {
 	s.rabbit = rabbit
 }
 
+func (s *SubscriberIntegrationSuite) TearDownTest() {
+	deleteTopic("amqp://guest:guest@localhost:5672", s.exchange, s.queue)
+}
+
 func (s *SubscriberIntegrationSuite) TestNewSubscriber() {
 	assert := s.Assert()
 

--- a/amqp/subscriber_test.go
+++ b/amqp/subscriber_test.go
@@ -32,7 +32,6 @@ func (s *SubscriberIntegrationSuite) SetupTest() {
 		rabbit, err = cli.CreateProxy("rabbit", ":35672", "mq:5672")
 	}
 	s.rabbit = rabbit
-
 }
 
 func (s *SubscriberIntegrationSuite) TestNewSubscriber() {

--- a/amqp/utils.go
+++ b/amqp/utils.go
@@ -57,3 +57,27 @@ func declareTopic(dsn, exchange, queue string) {
 		log.Fatalf("cannot bind: %v", err)
 	}
 }
+
+func deleteTopic(dsn, exchange, queue string) {
+	conn, err := amqp.Dial(dsn)
+	if err != nil {
+		log.Fatalf("cannot (re)dial: %v: %q", err, dsn)
+	}
+
+	ch, err := conn.Channel()
+	if err != nil {
+		log.Fatalf("cannot create channel: %v", err)
+	}
+
+	if err := ch.QueueUnbind(queue, "", exchange, nil); err != nil {
+		log.Fatalf("cannot unbind: %v", err)
+	}
+
+	if _, err := ch.QueueDelete(queue, false, false, false); err != nil {
+		log.Fatalf("cannot delete queue: %v", err)
+	}
+
+	if err := ch.ExchangeDelete(exchange, false, false); err != nil {
+		log.Fatalf("cannot delete exchange: %v", err)
+	}
+}


### PR DESCRIPTION
This allows to do a more cleaner setup, declarations basically are done at the entrypoint level, if you could not declare, the application could not start anyways

**Using new convention**
```go
        bus, err := amqp.NewBus(amqp.SetBusDSN("amqp://guest:guest@docker:5672"))
	if err != nil {
		log.Panic(err)
	}

	events, err := bus.NewPublisher(amqp.SetPublisherExchange("events"))
	if err != nil {
		log.Panic(err)
	}
	go publish(events, "events", time.Second)

	eventsa, err := bus.NewSubscriber(amqp.SetSubscriberQueue("event_queue_a"))
	if err != nil {
		log.Panic(err)
	}
	go subscribe(eventsa, "eventsa", time.Second)
```

**Using Must convention**
```go
       bus := amqp.MustBus(amqp.SetBusDSN("amqp://guest:guest@docker:5672"))

	events := bus.MustPublisher(amqp.SetPublisherExchange("events"))
	go publish(events, "events", time.Second)

	eventsa := bus.MustSubscriber(amqp.SetSubscriberQueue("event_queue_a"))
	go subscribe(eventsa, "eventsa", time.Second)
```