### PR TITLE
Adding shutdown function

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -1,8 +1,11 @@
 package bus
 
+import "context"
+
 type Bus interface {
 	Wait()
 	Close()
+	Shutdown(context.Context) error
 }
 
 type Publisher interface {


### PR DESCRIPTION
Provides a way to Shutdown gracefully with a timeout config, having the same signature as https://golang.org/pkg/net/http/#Server.Shutdown